### PR TITLE
Changes to make profile cards display correctly

### DIFF
--- a/frontend/src/components/ProfileCard.jsx
+++ b/frontend/src/components/ProfileCard.jsx
@@ -31,7 +31,7 @@ const ProfileCard = () => {
             if (prevIdx + 1 < displayedProfiles.length) {
                 return prevIdx + 1;
             }
-            setMoreProfiles(true);
+            setMoreProfiles(false);
             return 0;
         });
     };


### PR DESCRIPTION
**Summary**

Correctly sets more profiles to false when the index is past the number of profiles. This helps make profile cards show as intended and profiles that are already liked not show up.